### PR TITLE
ci: add GitHub Actions workflows for testing and npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'unbroken-markdown@*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
+        run: bun test
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run linter
+        run: bun run lint
+
+      - name: Check formatting
+        run: bun run format:check
+
+      - name: Run tests
+        run: bun test
+
+      - name: Build
+        run: bun run build


### PR DESCRIPTION
## 변경사항
- GitHub Actions 워크플로우 2개 추가
  - `test.yml`: PR 및 main 브랜치 push 시 자동 테스트 실행
  - `publish.yml`: 태그 푸시 시 npm 자동 배포

## 세부 내용
### 테스트 워크플로우 (`test.yml`)
- Node.js 20.x, 22.x 버전에서 매트릭스 테스트
- Bun을 사용한 의존성 설치 및 빌드
- 린트, 포맷 체크, 테스트 실행

### 배포 워크플로우 (`publish.yml`)
- `unbroken-markdown@*` 태그 푸시 시 트리거
- npm 레지스트리에 자동 배포
- 배포 전 테스트 및 빌드 검증

## 테스트 방법
1. PR 생성 시 자동으로 테스트 워크플로우 실행 확인
2. 태그 생성 후 푸시하여 배포 워크플로우 동작 확인

## 체크리스트
- [x] GitHub Actions 워크플로우 파일 추가
- [x] Node.js 버전 매트릭스 설정 (20.x, 22.x)
- [x] Bun 패키지 매니저 지원
- [ ] GitHub Secrets에 `NPM_TOKEN` 설정 필요