### PR TITLE
fix: move question mark outside bold markdown in Korean sentences

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -261,5 +261,13 @@ Guillermo는 "**개발자가 새 노트북을 받을 때 느끼는 쾌적한 준
       const expected = '**Bold**% and *Italic*% text';
       expect(unbreak(input)).toBe(expected);
     });
+
+    test('should move question mark outside of bold markdown in Korean sentence', () => {
+      const input =
+        '마지막으로 등장하는 논의는 **LLM이 이미 자체적으로 문제 생성기를 만들고, 정답지도 만들 수 있다면 이런 데이터 변환의 실질적 가치는 무엇인가?**라는 물음이다.';
+      const expected =
+        '마지막으로 등장하는 논의는 **LLM이 이미 자체적으로 문제 생성기를 만들고, 정답지도 만들 수 있다면 이런 데이터 변환의 실질적 가치는 무엇인가**?라는 물음이다.';
+      expect(unbreak(input)).toBe(expected);
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ const PUNCTUATION_RULES: Array<[RegExp, string]> = [
   // Percentage sign handling (e.g., **21%** → **21**%)
   // Use [^%]+? to prevent bold % only
   [/\*\*([^%]+?)%\*\*/g, '**$1**%'],
+  // Question mark handling (e.g., **text?** → **text**?)
+  [/\*\*([^?]+?)\?\*\*/g, '**$1**?'],
 ];
 
 /**


### PR DESCRIPTION
## 변경사항

한국어 문장에서 물음표가 볼드 마크다운 안에 포함되어 있을 때, 물음표를 볼드 밖으로 이동시키는 기능을 추가했습니다.

### 수정 내용
- `PUNCTUATION_RULES`에 물음표 처리 규칙 추가
- `**텍스트?**` → `**텍스트**?` 형태로 변환되도록 정규식 패턴 추가
- 한국어 문장에서 강조된 질문 뒤에 오는 물음표를 올바른 위치로 이동

## 테스트 방법

```bash
bun test
```

새로운 테스트 케이스가 추가되어 한국어 문장에서 물음표가 올바르게 처리되는지 확인합니다.

## 체크리스트

- [x] 물음표 처리 규칙 추가
- [x] 유닛 테스트 작성 및 통과
- [x] 기존 테스트에 영향 없음 확인
- [x] 다른 구두점 처리와 일관성 유지