### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unbroken-markdown",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "Fix broken markdown formatting by moving punctuation outside bold/italic text and removing incomplete image markdown during streaming",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump version from 0.1.1 to 0.1.2 for npm release

## Changes in 0.1.2
- Add angle brackets (`<>`) support for bold/italic
- Add Korean quotation marks support: `『』` `「」` `《》` `〈〉`

## After merge
Create and push tag to trigger npm publish:
```bash
git tag unbroken-markdown@0.1.2
git push origin unbroken-markdown@0.1.2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)