### PR TITLE
ci: add automatic GitHub Release creation on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,3 +35,8 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Add automatic GitHub Release creation step to publish workflow
- Uses `softprops/action-gh-release@v2` with auto-generated release notes

## Changes
When a new tag is pushed, the workflow will now:
1. Run tests
2. Build
3. Publish to npm
4. **Create GitHub Release** (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)