### PR TITLE
fix(core): protect code segments from transformation rules

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -383,4 +383,53 @@ Guillermo는 "**개발자가 새 노트북을 받을 때 느끼는 쾌적한 준
       expect(unbreak('***`text`***')).toBe('`text`');
     });
   });
+
+  describe('Code segment protection', () => {
+    test('should not modify content inside fenced code blocks', () => {
+      const input = '```md\n**"text"**\n```';
+      expect(unbreak(input)).toBe(input);
+    });
+
+    test('should not modify fenced code blocks with language and surrounding text', () => {
+      const input = '아래 예시를 보세요.\n\n```ts\nconst x = unbreak(\'**"x"**\');\n```\n\n끝.';
+      expect(unbreak(input)).toBe(input);
+    });
+
+    test('should not normalize smart quotes inside fenced code blocks', () => {
+      const input = '```\nconst s = ‘smart’ + “quotes”;\n```';
+      expect(unbreak(input)).toBe(input);
+    });
+
+    test('should not modify tilde-fenced code blocks', () => {
+      const input = '~~~\n**50%**\n~~~';
+      expect(unbreak(input)).toBe(input);
+    });
+
+    test('should not modify an unclosed fenced code block during streaming', () => {
+      const input = '설명 텍스트\n\n```js\nconst pct = "**50%**";';
+      expect(unbreak(input)).toBe(input);
+    });
+
+    test('should not modify content inside inline code', () => {
+      const input = 'use `**"x"**` literally';
+      expect(unbreak(input)).toBe(input);
+    });
+
+    test('should not normalize smart quotes inside inline code', () => {
+      const input = '인라인 코드 `‘quoted’` 예시';
+      expect(unbreak(input)).toBe(input);
+    });
+
+    test('should still fix patterns outside code segments', () => {
+      const input = '**"제목"** 설명\n\n```\n**"코드 안"**\n```\n\n그리고 **21%** 증가';
+      const expected = '"**제목**" 설명\n\n```\n**"코드 안"**\n```\n\n그리고 **21**% 증가';
+      expect(unbreak(input)).toBe(expected);
+    });
+
+    test('should still strip bold wrapping around inline code', () => {
+      const input = '**`Jules`**는 도구입니다. 코드 안 `**"x"**`는 유지.';
+      const expected = '`Jules`는 도구입니다. 코드 안 `**"x"**`는 유지.';
+      expect(unbreak(input)).toBe(expected);
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,11 +134,47 @@ const INCOMPLETE_IMAGE_PATTERNS: RegExp[] = [
 ];
 
 /**
+ * Fenced code blocks (``` or ~~~), including an unclosed trailing fence
+ * so that partially streamed code blocks are also protected
+ */
+const FENCED_CODE_PATTERN = /(`{3,}|~{3,})[\s\S]*?(?:\1|$)/g;
+
+/**
+ * Inline code spans (single line, backtick-delimited)
+ */
+const INLINE_CODE_PATTERN = /(`+)[^`\n]+?\1(?!`)/g;
+
+/**
+ * Replaces each match of `pattern` with a placeholder (\x00<tag><index>\x00)
+ * and stores the original text in `store` for later restoration.
+ * The placeholder contains no characters that transformation rules can match,
+ * so masked segments pass through all rules untouched.
+ */
+function maskSegments(text: string, pattern: RegExp, store: string[], tag: string): string {
+  return text.replace(pattern, (match) => {
+    store.push(match);
+    return `\x00${tag}${store.length - 1}\x00`;
+  });
+}
+
+/**
+ * Restores placeholders created by maskSegments back to their original text
+ */
+function restoreSegments(text: string, store: string[], tag: string): string {
+  return text.replace(
+    new RegExp(`\\x00${tag}(\\d+)\\x00`, 'g'),
+    (_, index) => store[Number(index)]
+  );
+}
+
+/**
  * Fixes broken markdown to ensure proper rendering.
  *
  * Main features:
  * 1. Move punctuation outside of Bold/Italic text for better typography
  * 2. Remove incomplete image markdown during streaming for rendering stability
+ *
+ * Code segments (fenced code blocks and inline code) are never modified.
  *
  * @param markdown - The markdown string to fix
  * @returns Unbroken markdown string
@@ -148,17 +184,26 @@ export function unbreak(markdown: string): string {
 
   let result = markdown;
 
+  // Mask fenced code blocks first so no rule (including quote normalization
+  // and inline-code unwrapping) can touch their content
+  const fencedBlocks: string[] = [];
+  result = maskSegments(result, FENCED_CODE_PATTERN, fencedBlocks, 'FENCE');
+
+  // Remove bold/italic wrapping around inline code
+  // Inline code already has visual distinction (monospace + background), bold/italic is redundant
+  // Must be applied before inline code masking, since it matches the backticks themselves
+  result = result.replaceAll(/\*\*`([^`\n]+)`\*\*/g, '`$1`');
+  result = result.replaceAll(/(?<!\*)\*`([^`\n]+)`\*(?!\*)/g, '`$1`');
+
+  // Mask inline code spans so the remaining rules cannot alter their content
+  const inlineCodes: string[] = [];
+  result = maskSegments(result, INLINE_CODE_PATTERN, inlineCodes, 'CODE');
+
   // Normalize Unicode quotes to ASCII
   result = result.replaceAll('\u2018', "'");
   result = result.replaceAll('\u2019', "'");
   result = result.replaceAll('\u201C', '"');
   result = result.replaceAll('\u201D', '"');
-
-  // Remove bold/italic wrapping around inline code
-  // Inline code already has visual distinction (monospace + background), bold/italic is redundant
-  // Must be applied before other rules to prevent interference (e.g., parentheses rules breaking backtick boundaries)
-  result = result.replaceAll(/\*\*`([^`\n]+)`\*\*/g, '`$1`');
-  result = result.replaceAll(/(?<!\*)\*`([^`\n]+)`\*(?!\*)/g, '`$1`');
 
   // Simple approach: only convert **"text"** that comes after space or line start
   // This way "**text**" pattern is not converted
@@ -205,6 +250,10 @@ export function unbreak(markdown: string): string {
   for (const pattern of INCOMPLETE_IMAGE_PATTERNS) {
     result = result.replace(pattern, '');
   }
+
+  // Restore masked code segments
+  result = restoreSegments(result, inlineCodes, 'CODE');
+  result = restoreSegments(result, fencedBlocks, 'FENCE');
 
   return result;
 }


### PR DESCRIPTION
## 배경 / 맥락

production-ready 점검에서 발견한 문제들을 수정하는 4건의 PR 중 두 번째입니다. (1번: #7 패키징 수정)

## 문제

변환 규칙(정규식)이 문서 전체에 적용되어 코드 구간의 내용까지 변조됩니다.

```
입력: ```md
      **"text"**
      ```
출력: ```md
      "**text**"      ← 코드 예시가 변조됨
      ```
```

스마트 따옴표(`''`, `""`) → ASCII 정규화도 코드 내용에 적용되어, 코드 블록 안의 문자열 리터럴이 바뀝니다. 인라인 코드는 일부 규칙의 `(^|\s)` 조건 덕분에 우연히 보호되는 경우가 있었을 뿐, 구조적인 보호 장치가 없었습니다.

## 해결

규칙 적용 전에 코드 구간을 플레이스홀더(`\x00<tag><index>\x00`)로 마스킹하고, 모든 변환이 끝난 뒤 복원합니다. 플레이스홀더에는 규칙이 매칭할 수 있는 문자가 없어 모든 규칙을 그대로 통과합니다.

처리 순서:

1. 펜스 코드 블록 마스킹 — ``` 와 ~~~ 모두 지원, 스트리밍 중 아직 닫히지 않은 펜스는 문서 끝까지 보호
2. 인라인 코드를 감싼 bold/italic 제거 (기존 규칙 — 백틱 자체를 매칭해야 하므로 마스킹 전에 실행)
3. 인라인 코드 스팬 마스킹
4. 기존 변환 규칙 전체 적용
5. 마스킹 복원

## 변경 사항

- `src/index.ts`: `FENCED_CODE_PATTERN`/`INLINE_CODE_PATTERN` 추가, `maskSegments`/`restoreSegments` 헬퍼 추가, `unbreak` 처리 순서 재구성
- `src/index.test.ts`: 코드 보호 테스트 9건 추가 (펜스/틸드 펜스/미종료 펜스/인라인 코드/스마트 따옴표/코드 밖 규칙 정상 동작 확인)

## 영향도 / 리스크

- 코드 구간이 없는 입력의 동작은 변하지 않습니다 (기존 테스트 58건 전부 그대로 통과).
- 인라인 코드 매칭은 한 줄 내로 제한했습니다. 여러 줄에 걸친 인라인 코드(CommonMark에서는 허용)는 마스킹되지 않지만, 기존 inline-code 규칙들과 동일한 제약입니다.

## 테스트

- 신규 9건 포함 67개 테스트 전체 통과
- `unbreak(unbreak(x)) === unbreak(x)` idempotency가 마스킹 도입 후에도 유지되는 것을 별도 스크립트로 확인
- `lint`/`format:check` 통과
