### PR TITLE
feat(api): add options with streaming, normalizeQuotes, moveQuestionMark

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,38 @@ console.log(italicOutput); // *text*(info)
 
 ### Streaming Support
 
-- Removes incomplete image markdown patterns
+With `streaming: true`:
+
+- Removes incomplete image markdown patterns (e.g. `![alt](https://…` cut off mid-stream)
 - Handles partial markdown during real-time streaming
 - Ensures consistent rendering even with interrupted markdown
 
+```typescript
+// While streaming, run intermediate chunks with streaming: true
+const partial = unbreak(accumulatedText, { streaming: true });
+
+// Run the final, complete document without it so legitimate
+// trailing "!" or "![" content is preserved
+const final = unbreak(fullText);
+```
+
+### Code Segment Protection
+
+Fenced code blocks (` ``` ` and `~~~`, including a not-yet-closed fence during streaming) and inline code spans are never modified.
+
 ## API
 
-### `unbreak(markdown: string): string`
+### `unbreak(markdown: string, options?: UnbreakOptions): string`
 
 The main function that processes and fixes broken markdown text.
 
 **Parameters:**
 
 - `markdown` - The markdown string to process
+- `options` - Optional behavior toggles:
+  - `streaming` (default `false`) - Remove trailing incomplete image markdown. Enable for intermediate chunks while streaming; leave off for complete documents.
+  - `normalizeQuotes` (default `true`) - Normalize Unicode smart quotes (`‘ ’ “ ”`) to ASCII quotes so quote rules can match them.
+  - `moveQuestionMark` (default `true`) - Move a trailing question mark outside bold (`**text?**` → `**text**?`).
 
 **Returns:**
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -432,4 +432,60 @@ Guillermo는 "**개발자가 새 노트북을 받을 때 느끼는 쾌적한 준
       expect(unbreak(input)).toBe(expected);
     });
   });
+
+  describe('Options', () => {
+    describe('streaming', () => {
+      test('should keep a trailing exclamation mark by default', () => {
+        expect(unbreak('Hello world!')).toBe('Hello world!');
+        expect(unbreak('정말 멋져요!')).toBe('정말 멋져요!');
+      });
+
+      test('should keep trailing partial image syntax by default', () => {
+        expect(unbreak('각주 참고![')).toBe('각주 참고![');
+        expect(unbreak('![alt text')).toBe('![alt text');
+      });
+
+      test('should remove a trailing incomplete image link when streaming', () => {
+        expect(unbreak('본문 ![이미지](https://example.com/a.pn', { streaming: true })).toBe(
+          '본문 '
+        );
+      });
+
+      test('should remove trailing partial image markers when streaming', () => {
+        expect(unbreak('본문 ![alt text', { streaming: true })).toBe('본문 ');
+        expect(unbreak('본문 ![', { streaming: true })).toBe('본문 ');
+        expect(unbreak('본문 !', { streaming: true })).toBe('본문 ');
+      });
+
+      test('should keep a complete image when streaming', () => {
+        const input = '![alt](https://example.com/a.png)';
+        expect(unbreak(input, { streaming: true })).toBe(input);
+      });
+    });
+
+    describe('normalizeQuotes', () => {
+      test('should normalize smart quotes by default', () => {
+        expect(unbreak('‘인용’과 “인용”')).toBe('\'인용\'과 "인용"');
+      });
+
+      test('should keep smart quotes when disabled', () => {
+        const input = '‘인용’과 “인용”';
+        expect(unbreak(input, { normalizeQuotes: false })).toBe(input);
+      });
+    });
+
+    describe('moveQuestionMark', () => {
+      test('should move a trailing question mark outside bold by default', () => {
+        expect(unbreak('**Really?**')).toBe('**Really**?');
+      });
+
+      test('should keep the question mark inside bold when disabled', () => {
+        expect(unbreak('**Really?**', { moveQuestionMark: false })).toBe('**Really?**');
+      });
+
+      test('should not affect other rules when disabled', () => {
+        expect(unbreak('**21%**', { moveQuestionMark: false })).toBe('**21**%');
+      });
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
 /**
+ * Question mark handling (e.g., **text?** → **text**?)
+ * Kept as a named rule so it can be disabled via the moveQuestionMark option,
+ * since bolding a whole question (e.g. **Really?**) can be intentional
+ */
+const BOLD_QUESTION_MARK_RULE: [RegExp, string] = [/\*\*([^?]+?)\?\*\*/g, '**$1**?'];
+
+/**
  * Transformation rules to move punctuation outside of bold markdown
  * Each rule is in the format [regex, replacement string]
  */
@@ -21,8 +28,7 @@ const PUNCTUATION_RULES: Array<[RegExp, string]> = [
   // Percentage sign handling (e.g., **21%** → **21**%)
   // Use [^%]+? to prevent bold % only
   [/\*\*([^%]+?)%\*\*/g, '**$1**%'],
-  // Question mark handling (e.g., **text?** → **text**?)
-  [/\*\*([^?]+?)\?\*\*/g, '**$1**?'],
+  BOLD_QUESTION_MARK_RULE,
   // Angle brackets handling (e.g., **<text>** → <**text**>)
   [/\*\*<([^<>*\n]+)>\*\*/g, '<**$1**>'],
   // Korean brackets handling
@@ -168,19 +174,48 @@ function restoreSegments(text: string, store: string[], tag: string): string {
 }
 
 /**
+ * Options for the unbreak function
+ */
+export interface UnbreakOptions {
+  /**
+   * Remove trailing incomplete image markdown (e.g. `![alt](https://…` cut
+   * off mid-stream). Enable this for intermediate chunks while streaming;
+   * leave it off for complete documents, where a trailing `!` or `![` is
+   * legitimate content and must not be removed.
+   * @default false
+   */
+  streaming?: boolean;
+  /**
+   * Normalize Unicode smart quotes (‘ ’ “ ”) to ASCII quotes (' ") so that
+   * the quote-related rules can match them.
+   * @default true
+   */
+  normalizeQuotes?: boolean;
+  /**
+   * Move a trailing question mark outside bold (**text?** → **text**?).
+   * Disable if bolding whole questions is intentional in your content.
+   * @default true
+   */
+  moveQuestionMark?: boolean;
+}
+
+/**
  * Fixes broken markdown to ensure proper rendering.
  *
  * Main features:
  * 1. Move punctuation outside of Bold/Italic text for better typography
- * 2. Remove incomplete image markdown during streaming for rendering stability
+ * 2. With `streaming: true`, remove incomplete image markdown for rendering stability
  *
  * Code segments (fenced code blocks and inline code) are never modified.
  *
  * @param markdown - The markdown string to fix
+ * @param options - Optional behavior toggles
  * @returns Unbroken markdown string
  */
-export function unbreak(markdown: string): string {
+export function unbreak(markdown: string, options: UnbreakOptions = {}): string {
   if (!markdown) return markdown;
+
+  const { streaming = false, normalizeQuotes = true, moveQuestionMark = true } = options;
 
   let result = markdown;
 
@@ -200,10 +235,12 @@ export function unbreak(markdown: string): string {
   result = maskSegments(result, INLINE_CODE_PATTERN, inlineCodes, 'CODE');
 
   // Normalize Unicode quotes to ASCII
-  result = result.replaceAll('\u2018', "'");
-  result = result.replaceAll('\u2019', "'");
-  result = result.replaceAll('\u201C', '"');
-  result = result.replaceAll('\u201D', '"');
+  if (normalizeQuotes) {
+    result = result.replaceAll('\u2018', "'");
+    result = result.replaceAll('\u2019', "'");
+    result = result.replaceAll('\u201C', '"');
+    result = result.replaceAll('\u201D', '"');
+  }
 
   // Simple approach: only convert **"text"** that comes after space or line start
   // This way "**text**" pattern is not converted
@@ -229,7 +266,7 @@ export function unbreak(markdown: string): string {
   const nonQuoteRules = PUNCTUATION_RULES.filter(([pattern]) => {
     const patternStr = pattern.toString();
     return !patternStr.includes('"') && !patternStr.includes("'");
-  });
+  }).filter((rule) => moveQuestionMark || rule !== BOLD_QUESTION_MARK_RULE);
 
   for (const [pattern, replacement] of nonQuoteRules) {
     result = result.replaceAll(pattern, replacement);
@@ -246,9 +283,12 @@ export function unbreak(markdown: string): string {
     result = result.replaceAll(pattern, replacement);
   }
 
-  // Remove incomplete image markdown
-  for (const pattern of INCOMPLETE_IMAGE_PATTERNS) {
-    result = result.replace(pattern, '');
+  // Remove incomplete image markdown (only while streaming — on a complete
+  // document a trailing "!" or "![" is legitimate content)
+  if (streaming) {
+    for (const pattern of INCOMPLETE_IMAGE_PATTERNS) {
+      result = result.replace(pattern, '');
+    }
   }
 
   // Restore masked code segments


### PR DESCRIPTION
## 배경 / 맥락

production-ready 점검 수정 PR 4건 중 세 번째입니다. (1번: #7 패키징, 2번: #8 코드 보호)

> **Note**: #8 위에 스택된 PR입니다. #8이 먼저 머지되면 base가 main으로 바뀝니다.

## 문제

1. **문장 끝 느낌표가 삭제됩니다.** 스트리밍 중 잘린 이미지 마크다운을 제거하는 `INCOMPLETE_IMAGE_PATTERNS`의 `/!$/` 패턴이 무조건 적용되어, 완성된 문서에서도 trailing `!`를 지웁니다:
   - `unbreak('Hello world!')` → `'Hello world'`
   - `unbreak('정말 멋져요!')` → `'정말 멋져요'`

   스트리밍 중간 청크에는 맞는 휴리스틱이지만 완성 문서에는 명백한 데이터 손상입니다.
2. 호불호가 갈리는 두 동작이 강제됩니다:
   - 스마트 따옴표(`''`, `""`) → ASCII 정규화가 bold/italic과 무관한 본문 전체에 적용
   - 물음표 이동 규칙이 의도적인 `**Really?**` 강조도 `**Really**?`로 풀어버림

## 해결

`unbreak(markdown, options?)` 형태로 옵션 파라미터를 추가했습니다:

| 옵션 | 기본값 | 동작 |
|---|---|---|
| `streaming` | `false` | trailing 불완전 이미지 마크다운 제거. 스트리밍 중간 청크에만 켜고, 완성 문서에는 끔 |
| `normalizeQuotes` | `true` | 스마트 따옴표 → ASCII 정규화 |
| `moveQuestionMark` | `true` | `**text?**` → `**text**?` 이동 |

## 변경 사항

- `src/index.ts`: `UnbreakOptions` 인터페이스 추가(export), 물음표 규칙을 `BOLD_QUESTION_MARK_RULE`로 분리해 토글 가능하게 변경, incomplete-image 제거를 `streaming` 옵션 뒤로 이동
- `src/index.test.ts`: 옵션 동작 테스트 10건 추가
- `README.md`: API 섹션에 옵션 문서화, 스트리밍 사용 패턴(중간 청크 `streaming: true` / 최종 패스는 기본값) 안내 추가

## 영향도 / 리스크

- **기본 동작 변경 (breaking)**: 기존에는 잘린 이미지 패턴 제거가 항상 실행됐지만 이제 `streaming: true`일 때만 실행됩니다. 스트리밍 용도로 쓰던 소비자는 옵션을 켜야 합니다. 대신 완성 문서에서의 데이터 손상(느낌표 삭제)이 사라집니다. 0.x 버전이지만 릴리스 노트에 명시가 필요합니다.
- `normalizeQuotes`/`moveQuestionMark`는 기본값이 기존 동작과 동일해 영향이 없습니다.

## 테스트

- 신규 10건 포함 77개 테스트 전체 통과 (기존 67건 무수정 통과 — 기본 동작 유지 확인)
- `lint`/`format:check` 통과
