### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unbroken-markdown",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "description": "Fix broken markdown formatting by moving punctuation outside bold/italic text and removing incomplete image markdown during streaming",
   "keywords": [


### PR DESCRIPTION
## 배경 / 맥락

production-ready 점검 수정 4건(#7, #8, #10, #11)이 모두 머지되어 릴리스를 준비합니다.

## 변경 사항

- 버전 0.1.3 → 0.2.0

## 영향도 / 리스크

minor 버전을 올리는 이유는 #11의 기본 동작 변경 때문입니다:

- **breaking**: 잘린 이미지 마크다운 제거가 기본 실행에서 빠지고 `streaming: true` 옵션일 때만 실행됩니다. 스트리밍 용도 소비자는 옵션을 켜야 합니다.
- **fix**: `require('unbroken-markdown')`이 처음으로 정상 동작합니다 (#7).
- **fix**: 완성 문서의 trailing `!` 삭제, 코드 블록 내용 변조가 사라집니다 (#8, #11).

## 테스트

- 77개 테스트 전체 통과
