### PR TITLE
feat(core): fix CJK flanking breakage for trailing punctuation and CJK brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ console.log(italicOutput); // *text*(info)
 - Links: `**[text](url)**` → `[**text**](url)`
 - Angle brackets: `**<text>**` → `<**text**>`
 - Korean brackets: `**『text』**` → `『**text**』`, `**「text」**` → `「**text**」`, `**《text》**` → `《**text**》`, `**〈text〉**` → `〈**text**〉`
+- CJK brackets: `**【text】**` → `【**text**】`, `**〔text〕**` → `〔**text**〕`, `**（text）**` → `（**text**）`
+
+### CJK Flanking Fixes
+
+CommonMark's right-flanking rule rejects a closing delimiter that is preceded by punctuation and directly followed by a letter. In CJK text the next clause or particle attaches with no space, so patterns like these fail to render entirely. When (and only when) a letter or number follows the closing delimiter directly, trailing punctuation is moved outside:
+
+- ASCII: `**제목:**내용` → `**제목**:내용`, `**대박!**이라고` → `**대박**!이라고` (also `.` `,` `;` `~`)
+- Full-width: `**質問？**に` → `**質問**？に`, `**文章。**次` → `**文章**。次` (also `！` `、` `，` `：` `；` `…` `．` `～`)
+- Full-width parenthetical: `**텍스트（설명）**뒤에` → `**텍스트**（설명）뒤에`
+- GFM strikethrough: `~~취소!~~라고` → `~~취소~~!라고`
+
+Patterns that already render — `**Note:** text` (space after), `**文章。**` (end of input) — are left untouched.
 
 ### Italic Pattern Fixes
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,8 @@
         "@typescript-eslint/eslint-plugin": "^8.35.1",
         "@typescript-eslint/parser": "^8.35.1",
         "eslint": "^9.30.1",
+        "micromark": "^4.0.2",
+        "micromark-extension-gfm": "^3.0.0",
         "prettier": "^3.4.2",
         "tsup": "^8.5.1",
         "typescript": "^5.0.0",
@@ -154,9 +156,13 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@20.19.11", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow=="],
 
@@ -222,6 +228,8 @@
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
     "check-error": ["check-error@1.0.3", "", { "dependencies": { "get-func-name": "^2.0.2" } }, "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
@@ -242,9 +250,15 @@
 
     "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "deep-eql": ["deep-eql@4.1.4", "", { "dependencies": { "type-detect": "^4.0.0" } }, "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
 
@@ -363,6 +377,60 @@
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "@typescript-eslint/eslint-plugin": "^8.35.1",
     "@typescript-eslint/parser": "^8.35.1",
     "eslint": "^9.30.1",
+    "micromark": "^4.0.2",
+    "micromark-extension-gfm": "^3.0.0",
     "prettier": "^3.4.2",
     "tsup": "^8.5.1",
     "typescript": "^5.0.0",

--- a/src/cjk-flanking.test.ts
+++ b/src/cjk-flanking.test.ts
@@ -1,0 +1,263 @@
+import { micromark } from 'micromark';
+import { gfm, gfmHtml } from 'micromark-extension-gfm';
+import { describe, expect, test } from 'vitest';
+
+import { unbreak } from './index';
+
+/**
+ * Render with the same CommonMark+GFM parser stack consumers use
+ * (react-markdown is built on micromark), so every assertion verifies
+ * actual rendering behavior, not just string shapes.
+ */
+function render(markdown: string): string {
+  return micromark(markdown, { extensions: [gfm()], htmlExtensions: [gfmHtml()] });
+}
+
+function rendersEmphasis(markdown: string): boolean {
+  return /<(strong|em|del)>/.test(render(markdown));
+}
+
+/**
+ * The core contract for every "broken" case:
+ * 1. the input genuinely fails to render emphasis (proves the case is real)
+ * 2. unbreak produces the exact expected string
+ * 3. the output genuinely renders emphasis (proves the fix works)
+ * 4. unbreak is idempotent on its own output
+ */
+function expectFixed(input: string, expected: string): void {
+  expect(rendersEmphasis(input), `input should be broken: ${input}`).toBe(false);
+  const output = unbreak(input);
+  expect(output).toBe(expected);
+  expect(rendersEmphasis(output), `output should render: ${output}`).toBe(true);
+  expect(unbreak(output)).toBe(output);
+}
+
+/**
+ * The contract for every "already fine" case: rendering works before and
+ * after, and unbreak leaves the string untouched.
+ */
+function expectUntouched(input: string): void {
+  expect(rendersEmphasis(input), `input should render: ${input}`).toBe(true);
+  expect(unbreak(input)).toBe(input);
+}
+
+describe('CJK flanking fixes', () => {
+  describe('bold with trailing ASCII punctuation directly followed by CJK', () => {
+    test('colon', () => {
+      expectFixed('**제목:**내용이 이어진다', '**제목**:내용이 이어진다');
+    });
+
+    test('exclamation mark', () => {
+      expectFixed('**대박!**이라고 했다', '**대박**!이라고 했다');
+    });
+
+    test('period', () => {
+      expectFixed('**끝.**입니다', '**끝**.입니다');
+    });
+
+    test('comma', () => {
+      expectFixed('**먼저,**그리고', '**먼저**,그리고');
+    });
+
+    test('semicolon', () => {
+      expectFixed('**구분;**다음', '**구분**;다음');
+    });
+
+    test('tilde (breaks only without GFM: the strikethrough tokenizer changes ~ handling)', () => {
+      const input = '**3시~**까지';
+      const plainCommonmark = (md: string) => /<(strong|em)>/.test(micromark(md));
+      expect(plainCommonmark(input), 'broken under plain CommonMark').toBe(false);
+      const output = unbreak(input);
+      expect(output).toBe('**3시**~까지');
+      expect(plainCommonmark(output), 'fixed under plain CommonMark').toBe(true);
+      expect(rendersEmphasis(output), 'still renders under GFM').toBe(true);
+      expect(unbreak(output)).toBe(output);
+    });
+
+    test('consecutive punctuation', () => {
+      expectFixed('**정말!.**이라며', '**정말**!.이라며');
+    });
+  });
+
+  describe('bold with trailing full-width punctuation', () => {
+    test('full-width question mark (Korean)', () => {
+      expectFixed('**질문？**에 대한 답', '**질문**？에 대한 답');
+    });
+
+    test('full-width exclamation mark (Korean)', () => {
+      expectFixed('**경고！**라고', '**경고**！라고');
+    });
+
+    test('ideographic full stop (Japanese)', () => {
+      expectFixed('**文章。**次の文', '**文章**。次の文');
+    });
+
+    test('ideographic comma (Japanese)', () => {
+      expectFixed('**まず、**次に', '**まず**、次に');
+    });
+
+    test('full-width comma (Chinese)', () => {
+      expectFixed('**首先，**然后', '**首先**，然后');
+    });
+
+    test('full-width colon', () => {
+      expectFixed('**제목：**내용', '**제목**：내용');
+    });
+
+    test('full-width semicolon', () => {
+      expectFixed('**구분；**다음', '**구분**；다음');
+    });
+
+    test('horizontal ellipsis', () => {
+      expectFixed('**그리고…**다음', '**그리고**…다음');
+    });
+
+    test('full-width full stop', () => {
+      expectFixed('**完．**次', '**完**．次');
+    });
+
+    test('wave dash (Japanese)', () => {
+      expectFixed('**３時～**まで', '**３時**～まで');
+    });
+  });
+
+  describe('bold with full-width parentheses', () => {
+    test('trailing parenthetical directly followed by CJK', () => {
+      expectFixed('**텍스트（설명）**뒤에 온다', '**텍스트**（설명）뒤에 온다');
+    });
+
+    test('fully wrapped content is moved outside', () => {
+      expectFixed('**（참고）**내용', '（**참고**）내용');
+    });
+
+    test('Japanese annotation pattern', () => {
+      expectFixed(
+        '**住吉の長屋（じゅうよしのながや）**は名作だ',
+        '**住吉の長屋**（じゅうよしのながや）は名作だ'
+      );
+    });
+  });
+
+  describe('bold with CJK bracket pairs', () => {
+    test('black lenticular brackets (Chinese notice)', () => {
+      expectFixed('**【公告】**内容', '【**公告**】内容');
+    });
+
+    test('black lenticular brackets (Korean)', () => {
+      expectFixed('**【중요】**확인 바랍니다', '【**중요**】확인 바랍니다');
+    });
+
+    test('tortoise shell brackets', () => {
+      expectFixed('**〔注〕**本文', '〔**注**〕本文');
+    });
+  });
+
+  describe('italic variants', () => {
+    test('trailing colon directly followed by CJK', () => {
+      expectFixed('*제목:*내용이 이어진다', '*제목*:내용이 이어진다');
+    });
+
+    test('trailing ideographic full stop', () => {
+      expectFixed('*文章。*次の文', '*文章*。次の文');
+    });
+
+    test('trailing full-width parenthetical', () => {
+      expectFixed('*텍스트（설명）*뒤에 온다', '*텍스트*（설명）뒤에 온다');
+    });
+
+    test('fully wrapped full-width parentheses', () => {
+      expectFixed('*（참고）*내용', '（*참고*）내용');
+    });
+
+    test('black lenticular brackets', () => {
+      expectFixed('*【公告】*内容', '【*公告*】内容');
+    });
+
+    test('tortoise shell brackets', () => {
+      expectFixed('*〔注〕*本文', '〔*注*〕本文');
+    });
+  });
+
+  describe('GFM strikethrough', () => {
+    test('trailing exclamation directly followed by CJK', () => {
+      expectFixed('~~취소!~~라고', '~~취소~~!라고');
+    });
+
+    test('trailing ideographic full stop', () => {
+      expectFixed('~~削除。~~次', '~~削除~~。次');
+    });
+
+    test('plain strikethrough stays untouched', () => {
+      expectUntouched('~~취소~~라고');
+    });
+  });
+
+  describe('cases that must stay untouched', () => {
+    test('trailing punctuation followed by a space renders fine', () => {
+      expectUntouched('**Note:** this is fine');
+      expectUntouched('**제목:** 내용');
+      expectUntouched('**대박!** 이라고');
+    });
+
+    test('trailing punctuation at end of input renders fine', () => {
+      expectUntouched('결론은 **이것입니다.**');
+      expectUntouched('**文章。**');
+    });
+
+    test('trailing punctuation followed by punctuation renders fine', () => {
+      expectUntouched('**제목:**, 그리고');
+    });
+
+    test('full-width parenthetical at end of input renders fine', () => {
+      expectUntouched('**텍스트（설명）**');
+    });
+
+    test('plain CJK bold with attached particle renders fine', () => {
+      expectUntouched('**단어**가 좋다');
+      expectUntouched('**言葉**が好き');
+      expectUntouched('**词语**很好');
+    });
+
+    test('punctuation inside the middle of bold renders fine', () => {
+      expectUntouched('**A・B 비교: 결과**가 나왔다');
+    });
+  });
+
+  describe('rendering verification of pre-existing rules', () => {
+    test('Korean corner brackets', () => {
+      expectFixed('**「제목」**을 읽다', '「**제목**」을 읽다');
+    });
+
+    test('ASCII double quotes', () => {
+      expectFixed('그는 **"인용"**이라 했다', '그는 "**인용**"이라 했다');
+    });
+
+    test('percentage', () => {
+      expectFixed('**50%**가 늘었다', '**50**%가 늘었다');
+    });
+
+    test('ASCII question mark', () => {
+      expectFixed('**무엇인가?**라는 질문', '**무엇인가**?라는 질문');
+    });
+  });
+
+  describe('interaction with other features', () => {
+    test('does not modify trailing punctuation patterns inside code segments', () => {
+      const inline = '코드 `**제목:**내용` 예시';
+      expect(unbreak(inline)).toBe(inline);
+      const fence = '```\n**제목:**내용\n```';
+      expect(unbreak(fence)).toBe(fence);
+    });
+
+    test('multiple fixes in one line', () => {
+      expectFixed(
+        '**첫째,**하나와 **둘째!**둘과 **【셋】**셋',
+        '**첫째**,하나와 **둘째**!둘과 【**셋**】셋'
+      );
+    });
+
+    test('mixed bold and italic in one line', () => {
+      expectFixed('**제목:**내용과 *부제목.*설명', '**제목**:내용과 *부제목*.설명');
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,12 @@ const PUNCTUATION_RULES: Array<[RegExp, string]> = [
   [/\*\*《([^《》*\n]+)》\*\*/g, '《**$1**》'],
   // 홑화살괄호 (artworks): **〈text〉** → 〈**text**〉
   [/\*\*〈([^〈〉*\n]+)〉\*\*/g, '〈**$1**〉'],
+  // Full-width parentheses: **（text）** → （**text**）
+  [/\*\*（([^（）*\n]+)）\*\*/g, '（**$1**）'],
+  // Black lenticular brackets (CJK notices/emphasis): **【text】** → 【**text**】
+  [/\*\*【([^【】*\n]+)】\*\*/g, '【**$1**】'],
+  // Tortoise shell brackets: **〔text〕** → 〔**text**〕
+  [/\*\*〔([^〔〕*\n]+)〕\*\*/g, '〔**$1**〕'],
 ];
 
 /**
@@ -75,6 +81,41 @@ const ITALIC_PUNCTUATION_RULES: Array<[RegExp, string]> = [
   [/(?<!\*)\*《([^《》*\n]+)》\*(?!\*)/g, '《*$1*》'],
   // 홑화살괄호 (artworks): *〈text〉* → 〈*text*〉
   [/(?<!\*)\*〈([^〈〉*\n]+)〉\*(?!\*)/g, '〈*$1*〉'],
+  // Full-width parentheses: *（text）* → （*text*）
+  [/(?<!\*)\*（([^（）*\n]+)）\*(?!\*)/g, '（*$1*）'],
+  // Black lenticular brackets: *【text】* → 【*text*】
+  [/(?<!\*)\*【([^【】*\n]+)】\*(?!\*)/g, '【*$1*】'],
+  // Tortoise shell brackets: *〔text〕* → 〔*text*〕
+  [/(?<!\*)\*〔([^〔〕*\n]+)〕\*(?!\*)/g, '〔*$1*〕'],
+];
+
+/**
+ * Trailing punctuation that breaks CommonMark emphasis in CJK text.
+ *
+ * Per the right-flanking rule, a closing delimiter preceded by punctuation
+ * only counts when it is followed by whitespace or punctuation. In CJK text,
+ * particles and the next clause attach with no space (e.g. **제목:**내용,
+ * **文章。**次), so the emphasis fails to render. These rules move the
+ * trailing punctuation outside the delimiter, but ONLY when a letter or
+ * number follows directly — **Note:** followed by a space renders fine and
+ * must stay untouched.
+ *
+ * ASCII ? and % are excluded here: they are handled unconditionally by the
+ * dedicated rules above. ASCII ~ only breaks plain CommonMark (GFM's
+ * strikethrough tokenizer changes its handling); moving it out is safe in
+ * both dialects.
+ */
+const TRAILING_PUNCT = '[:!.,;~？！。、，：；…．～]';
+const CJK_FLANKING_RULES: Array<[RegExp, string]> = [
+  // Bold: **제목:**내용 → **제목**:내용
+  [new RegExp(`\\*\\*([^*\\n]+?)(${TRAILING_PUNCT}+)\\*\\*(?=[\\p{L}\\p{N}])`, 'gu'), '**$1**$2'],
+  // Italic: *제목:*내용 → *제목*:내용
+  [new RegExp(`(?<!\\*)\\*([^*\\n]+?)(${TRAILING_PUNCT}+)\\*(?=[\\p{L}\\p{N}])`, 'gu'), '*$1*$2'],
+  // Full-width parenthetical before attached text: **텍스트（설명）**뒤 → **텍스트**（설명）뒤
+  [/\*\*([^*\n]+?)(（[^*\n（）]+?）)\*\*(?=[\p{L}\p{N}])/gu, '**$1**$2'],
+  [/(?<!\*)\*([^*\n]+?)(（[^*\n（）]+?）)\*(?=[\p{L}\p{N}])/gu, '*$1*$2'],
+  // GFM strikethrough: ~~취소!~~라고 → ~~취소~~!라고 (same flanking constraint)
+  [/(?<!~)~~([^~\n]+?)([:!.,;？！。、，：；…．]+)~~(?!~)(?=[\p{L}\p{N}])/gu, '~~$1~~$2'],
 ];
 
 /**
@@ -280,6 +321,12 @@ export function unbreak(markdown: string, options: UnbreakOptions = {}): string 
   });
 
   for (const [pattern, replacement] of nonQuoteItalicRules) {
+    result = result.replaceAll(pattern, replacement);
+  }
+
+  // Fix CJK flanking breakage: trailing punctuation directly followed by a
+  // letter/number prevents the closing delimiter from being right-flanking
+  for (const [pattern, replacement] of CJK_FLANKING_RULES) {
     result = result.replaceAll(pattern, replacement);
   }
 


### PR DESCRIPTION
## 배경 / 맥락

CJK 언어에서 마크다운이 깨지지 않는지 더블체크한 결과, 기존 규칙이 다루지 못하는 패턴군을 발견했습니다. harvest가 쓰는 react-markdown과 동일한 파서(micromark)로 실측해서 확인했습니다.

## 문제

CommonMark의 right-flanking 규칙상, 닫는 `**` 바로 앞이 구두점이고 바로 뒤에 글자가 공백 없이 붙으면 emphasis가 렌더링되지 않습니다. CJK는 조사·어미·다음 절이 공백 없이 붙기 때문에 이 조건에 자주 걸립니다:

- `**제목:**내용`, `**대박!**이라고`, `**끝.**입니다` (ASCII 구두점)
- `**質問？**に`, `**文章。**次`, `**首先，**然后`, `**제목：**내용` (전각 구두점)
- `**텍스트（설명）**뒤에` (전각 괄호), `**【公告】**内容` (흑괄호), `**〔注〕**本文`
- `~~취소!~~라고` (GFM 취소선)

모두 micromark에서 원본이 렌더링되지 않는 것을 확인했습니다.

## 해결

기존 규칙과 같은 move-outside 전략을 적용하되, **trailing 구두점 규칙은 닫는 delimiter 바로 뒤에 글자/숫자가 붙을 때만**(lookahead 조건) 발동합니다. `**Note:** 내용`(공백 뒤따름)이나 `**文章。**`(입력 끝)처럼 이미 정상 렌더링되는 패턴은 건드리지 않습니다. 감싸기형 괄호(`【】〔〕（）`)는 기존 낫표 규칙군과 동일하게 무조건 이동합니다.

## 변경 사항

- `src/index.ts`:
  - `CJK_FLANKING_RULES` 추가 — bold/italic trailing 구두점(`:!.,;~` + `？！。、，：；…．～`), 전각 괄호 trailing, GFM 취소선
  - 기존 bracket 규칙군에 `【】`/`〔〕`/`（）` 감싸기 규칙 추가 (bold/italic)
- `src/cjk-flanking.test.ts` 신규 — 45개 테스트
- `package.json`: `micromark`, `micromark-extension-gfm` devDependency 추가 (테스트 전용, 런타임 의존성 없음)
- `README.md`: CJK Flanking Fixes 섹션 추가

## 테스트 (검증 방식)

단순 문자열 비교가 아니라 실제 파서로 양방향 검증합니다. 모든 "깨짐" 케이스는 4단계 계약을 통과해야 합니다:

1. 원본이 micromark(+GFM)에서 **실제로 렌더링 실패**하는지 (케이스가 진짜임을 증명)
2. `unbreak` 출력이 기대 문자열과 정확히 일치하는지
3. 출력이 **실제로 렌더링되는지** (수정이 유효함을 증명)
4. `unbreak(unbreak(x)) === unbreak(x)` (idempotent)

"건드리면 안 되는" 케이스는 역방향 계약(원본이 정상 렌더 + 무변경)을 검증합니다. 이 방식 덕분에 설계 중 한 가지 사실도 발견했습니다: ASCII `~`는 GFM에서는 strikethrough 토크나이저 때문에 깨지지 않고 순수 CommonMark에서만 깨집니다 (해당 테스트는 두 dialect를 모두 검증).

- 전체 122개 테스트 통과 (기존 77개 무수정 통과)
- `typecheck`/`lint`/`format:check`/`build` 통과

## 영향도 / 리스크

- trailing 구두점 규칙은 "원본이 깨져 있던" 경우에만 발동하므로, 기존에 정상 렌더링되던 문서의 출력은 변하지 않습니다.
- 감싸기 괄호 규칙(`【】` 등)은 무조건 적용이지만 기존 낫표 규칙군과 동일한 패턴이며, 변환 전후 모두 렌더링에는 문제가 없습니다 (타이포그래피 일관성 목적).
- 알려진 한계: 문장 중간에서 여는 delimiter 바로 뒤가 구두점인 경우(`안내**（주의）내용**입니다`)는 left-flanking 문제로 이번 범위에서 제외했습니다.
