### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unbroken-markdown",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Fix broken markdown formatting by moving punctuation outside bold/italic text and removing incomplete image markdown during streaming",
   "keywords": [


### PR DESCRIPTION
## 배경 / 맥락

CJK flanking 수정(#13)이 머지되어 릴리스를 준비합니다.

## 변경 사항

- 버전 0.2.0 → 0.3.0

## 영향도 / 리스크

새 변환 규칙이 추가되는 minor 릴리스입니다. trailing 구두점 규칙은 원본이 렌더링되지 않던 경우에만 발동하므로, 기존에 정상 렌더링되던 문서의 출력은 변하지 않습니다.

## 테스트

- 122개 테스트 전체 통과 (실제 파서 렌더링 검증 포함)
